### PR TITLE
Add mode support for logging

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -58,7 +58,7 @@ def main():
     model_type = "reasoner" if model_choice == "2" else "chat"
     
     client = DeepSeekClient(mode=mode, model_type=model_type)
-    logger = ConversationLogger()
+    logger = ConversationLogger(mode_name=config.MODES[mode]["name"])
     turno = 1
     
     try:

--- a/src/logger.py
+++ b/src/logger.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from pathlib import Path
 
 class ConversationLogger:
-    def __init__(self):
+    def __init__(self, mode_name: str = "EsquizoAI"):
+        self.mode_name = mode_name
         # Crear directorio logs si no existe
         self.logs_dir = Path("logs")
         self.logs_dir.mkdir(exist_ok=True)
@@ -20,9 +21,10 @@ class ConversationLogger:
     
     def _log_session_start(self):
         """Registra el inicio de la sesión"""
-        header = f"""# Sesión EsquizoAI 🤪
+        header = f"""# Sesión {self.mode_name} 🤪
 
 ## Información de Sesión
+- **Modo**: {self.mode_name}
 - **Fecha**: {self.session_start.strftime("%Y-%m-%d")}
 - **Hora de inicio**: {self.session_start.strftime("%H:%M:%S")}
 - **Status**: Activa 💀
@@ -46,7 +48,7 @@ class ConversationLogger:
 """
         else:
             # Procesar el contenido para mantener el formato Markdown
-            message = f"""### 🤖 EsquizoAI [{timestamp}]
+            message = f"""### 🤖 {self.mode_name} [{timestamp}]
 {content}
 
 """


### PR DESCRIPTION
## Summary
- allow ConversationLogger to accept mode name
- inject mode name when launching the logger
- add mode heading in session logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual check of log output via a small Python snippet

------
https://chatgpt.com/codex/tasks/task_e_684f43c5c2e8832ba78364a3c5c201e2